### PR TITLE
Limit maximum open file handles for EMQX specifically

### DIFF
--- a/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
+++ b/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
@@ -23,5 +23,8 @@ for var in $(bashio::config 'env_vars|keys'); do
     export "${name}=${value}"
 done
 
+# Set max open file limit to avoid memory allocation issues
+ulimit -n 1048576
+
 # Run EMQX
 exec /opt/emqx/bin/emqx foreground


### PR DESCRIPTION
# Proposed Changes

Newer Docker versions (their default systemd service definitions) have a higher limit of open file handles than previously. It seems that EMQX allocates memory proportional to the limit of open file handles, which leads to out of memory errors on certain platforms.

Set the limit to the same value Docker has been using in earlier version.


## Related Issues

Fixes: #30
