### PR TITLE
Do not raise open file limit unnecessarily (fixes HAOS 16 compat)

### DIFF
--- a/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
+++ b/emqx/rootfs/etc/s6-overlay/s6-rc.d/emqx/run
@@ -25,7 +25,9 @@ for var in $(bashio::config 'env_vars|keys'); do
 done
 
 # Set max open file limit to avoid memory allocation issues
-ulimit -n 1048576
+if [ "$(ulimit -Hn)" -gt 524288 ]; then
+    ulimit -n 524288
+fi
 
 # Run EMQX
 exec /opt/emqx/bin/emqx foreground


### PR DESCRIPTION
# Proposed Changes

In #38 a fix to lower the open file limit to avoid memory allocation issues was implemented. However, if the file limit is lower already, the ulimit call may attempt to raise the (hard) limit, which would result in an error.

With containerd >=2.0.0, LimitNOFILE is no longer "infinity" (see [1]) for containers on Systemd installs and uses the default 524288. Check that the current hard limit is higher than this value and limit only then, fixing the permission error when the existing hard limit was higher.

This potentially also lowers memory usage because the new limit is lower, yet it should be large enough for standard operation.

This fixes home-assistant/operating-system#4085

[1] https://github.com/containerd/containerd/commit/3ca39ef01608fdd44245c0173bf071682b3bfe3c

## Related Issues

- home-assistant/operating-system#4085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of system file descriptor limits to prevent errors when the hard limit is lower than the default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->